### PR TITLE
Implement privacy feature to events

### DIFF
--- a/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Controller/EventController.java
+++ b/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Controller/EventController.java
@@ -53,6 +53,17 @@ public class EventController {
         return repository.findByName(name);
     }
 
+    //List events with respect to privacy option
+    //Example = localhost:8080/user?privacyoption=true
+    @RequestMapping(method = RequestMethod.GET, value = "",
+            params="privacyoption",
+        produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public @ResponseBody
+    List<Event> eventByPrivacyoption(@RequestParam("privacyoption") Boolean privacyoption){
+
+        return repository.findByPrivacyoption(privacyoption);
+    }
+    
     @RequestMapping(value="{name}", method = RequestMethod.POST)
     public @ResponseBody Event insertData(ModelMap model,
                                           @ModelAttribute("insertEvent") @Valid Event event,

--- a/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Controller/EventController.java
+++ b/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Controller/EventController.java
@@ -15,6 +15,7 @@
  */
 package com.bounswe.bounswe2017group3;
 
+import com.bounswe.bounswe2017group3.Exception.CustomException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
@@ -52,9 +53,9 @@ public class EventController {
 
         return repository.findByName(name);
     }
-
+    
     //List events with respect to privacy option
-    //Example = localhost:8080/user?privacyoption=true
+    //Example = localhost:8080/event?privacyoption=true
     @RequestMapping(method = RequestMethod.GET, value = "",
             params="privacyoption",
         produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
@@ -63,20 +64,19 @@ public class EventController {
 
         return repository.findByPrivacyoption(privacyoption);
     }
-    
-    @RequestMapping(value="{name}", method = RequestMethod.POST)
-    public @ResponseBody Event insertData(ModelMap model,
-                                          @ModelAttribute("insertEvent") @Valid Event event,
-                                          BindingResult result) {
 
-        if(!result.hasErrors()){
+    //Post code is revised.
+    @RequestMapping(method = RequestMethod.POST,
+        produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public @ResponseBody Event insertData(ModelMap model,
+                                         @ModelAttribute("insertEvent") @Valid Event event,
+                                         BindingResult result) {
+        if (!result.hasErrors()) {
             repository.save(event);
         }
-
         return event;
-
     }
-
+    
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse> exceptionHandler(Exception ex) {
         ErrorResponse error = new ErrorResponse();

--- a/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Model/Event.java
+++ b/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Model/Event.java
@@ -5,6 +5,7 @@ import org.hibernate.validator.constraints.NotEmpty;
 import javax.persistence.*;
 import java.io.Serializable;
 import java.util.Date;
+import javax.validation.constraints.NotNull;
 
 @Table(name = "events")
 @Entity
@@ -120,6 +121,18 @@ public class Event implements Serializable {
      */
     public void setDate(Date date) {this.date = date;}
 
+    /*
+    Privacy Option
+    */
+    @NotNull                        //Privacy option cannot be null
+    private Boolean privacyoption;  //Privacy option of the event.
+    
+    //Returns the privacy option of the event.
+    public Boolean getPrivacyoption() {return privacyoption;}
+    
+    //Sets the privacy option of the event.
+    public void setPrivacyoption(Boolean privacyoption) {this.privacyoption = privacyoption;}
+    
     /**
      * Returns the string representation of the event object.
      *
@@ -133,6 +146,7 @@ public class Event implements Serializable {
                 ", description='" + description + '\'' +
                 ", date='" + date + '\'' +
                 ", location='" + location + '\'' +
+                ", privacyoption='" + privacyoption + '\'' +
                 '}';
     }
 }

--- a/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Repository/EventRepository.java
+++ b/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Repository/EventRepository.java
@@ -10,7 +10,10 @@ import org.springframework.stereotype.Repository;
 public interface EventRepository extends JpaRepository<Event, Long> {
 
     public Event findByName(String name);
-
+    
+    //List events with respect to privacy option
+    public List<Event> findByPrivacyoption(Boolean privacyoption);
+    
     @Query("SELECT COUNT(e) FROM Event e where e.name = :name")
     public int numberOfEventsWithName(@Param("name") String name);
 

--- a/events-application-rest-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/events-application-rest-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -65,4 +65,8 @@ databaseChangeLog:
               - column:
                   name: date
                   type: timestamp
-
+              - column:
+                  name: privacyoption
+                  type: boolean
+                  constraints:
+                    nullable: false


### PR DESCRIPTION
## About
Privacy option is added to the project with this change.
* **Related Issues:** 
[Divide API tasks among team #72](https://github.com/bounswe/bounswe2017group3/issues/72)

### Changes

- Change 1. Privacy option is added to event class.
- Change 2. Database is adjusted for privacy option.
- Change 3. EventRepository and EventController files are altered to list events by considering privacy option.
- Change 4. Post code in EventController is revised.

## Testing

How can this contribution be tested? Use the following structure:

- Test step 1. Post an event with privacy option.
- Test step 2. Get this post.
- Test step 3. Post an event without privacy option.
- Test step 4. Try to get this post. The result must be null.
- Test step 5. Post an event with privacy option (with the value not being boolean).
- Test step 6. Try to get this post. The result must be null.
- Test step 7. List the events by privacy option. Send localhost:8080/event?privacyoption=false with Postman.
- Test step 8. The events without privacy must be listed.
- Test step 9. List the events by privacy option. Send localhost:8080/event?privacyoption=true with Postman.
- Test step 10. The events with privacy must be listed.
