### PR TITLE
Features/implementing privacy to events

### DIFF
--- a/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Controller/EventController.java
+++ b/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Controller/EventController.java
@@ -15,6 +15,7 @@
  */
 package com.bounswe.bounswe2017group3;
 
+import com.bounswe.bounswe2017group3.Exception.CustomException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
@@ -52,8 +53,18 @@ public class EventController {
 
         return repository.findByName(name);
     }
+    
+    @RequestMapping(method = RequestMethod.GET, value = "",
+            params="privacy",
+        produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public @ResponseBody
+    List<Event> eventByPrivacy(@RequestParam("privacy") Boolean privacy){
 
-    @RequestMapping(value="{name}", method = RequestMethod.POST)
+        return repository.findByPrivacy(privacy);
+    }
+
+    @RequestMapping(method = RequestMethod.POST,
+        produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public @ResponseBody Event insertData(ModelMap model,
                                           @ModelAttribute("insertEvent") @Valid Event event,
                                           BindingResult result) {

--- a/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Controller/EventController.java
+++ b/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Controller/EventController.java
@@ -54,6 +54,7 @@ public class EventController {
         return repository.findByName(name);
     }
     
+    //List events with respect to privacy option
     @RequestMapping(method = RequestMethod.GET, value = "",
             params="privacy",
         produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
@@ -63,6 +64,7 @@ public class EventController {
         return repository.findByPrivacy(privacy);
     }
 
+    //Post code is revised.
     @RequestMapping(method = RequestMethod.POST,
         produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
     public @ResponseBody Event insertData(ModelMap model,

--- a/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Model/Event.java
+++ b/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Model/Event.java
@@ -1,6 +1,7 @@
 package com.bounswe.bounswe2017group3;
 
 import org.hibernate.validator.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
 
 import javax.persistence.*;
 import java.io.Serializable;
@@ -119,7 +120,19 @@ public class Event implements Serializable {
      * @param date date of the event.
      */
     public void setDate(Date date) {this.date = date;}
-
+    
+    /*
+    Privacy Option
+    */
+    @NotNull                        //Privacy option cannot be null
+    private Boolean privacy;  //Privacy option of the event.
+    
+    //Returns the privacy option of the event.
+    public Boolean getPrivacy() {return privacy;}
+    
+    //Sets the privacy option of the event.
+    public void setPrivacy(Boolean privacy) {this.privacy = privacy;}
+    
     /**
      * Returns the string representation of the event object.
      *
@@ -133,6 +146,7 @@ public class Event implements Serializable {
                 ", description='" + description + '\'' +
                 ", date='" + date + '\'' +
                 ", location='" + location + '\'' +
+                ", privacy='" + privacy + '\'' +
                 '}';
     }
 }

--- a/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Model/Event.java
+++ b/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Model/Event.java
@@ -124,7 +124,7 @@ public class Event implements Serializable {
     /*
     Privacy Option
     */
-    @NotNull                        //Privacy option cannot be null
+    @NotNull                  //Privacy option cannot be null
     private Boolean privacy;  //Privacy option of the event.
     
     //Returns the privacy option of the event.

--- a/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Repository/EventRepository.java
+++ b/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Repository/EventRepository.java
@@ -11,6 +11,9 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     public Event findByName(String name);
 
+    //List events with respect to privacy option  
+    public List<Event> findByPrivacy(Boolean privacy);
+    
     @Query("SELECT COUNT(e) FROM Event e where e.name = :name")
     public int numberOfEventsWithName(@Param("name") String name);
 

--- a/events-application-rest-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/events-application-rest-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -65,4 +65,13 @@ databaseChangeLog:
               - column:
                   name: date
                   type: timestamp
-
+changeSet:
+  id: 4
+  author: MertKalaylioglu
+  changes:
+  - addColumn:
+      columns:
+      - column:
+          name: privacy
+          type: boolean
+      tableName: events


### PR DESCRIPTION
## About
Privacy option is added to the project with this change.
* **Related Issues:** 
[Divide API tasks among team #72](https://github.com/bounswe/bounswe2017group3/issues/72)
* **Related Pull Request:** 
[Implement privacy feature to events #78](https://github.com/bounswe/bounswe2017group3/pull/78)
### Changes

- Change 1. Privacy option is added to event class.
- Change 2. Database is adjusted for privacy option.
- Change 3. EventRepository and EventController files are altered to list events by considering privacy option.
- Change 4. Post code in EventController is revised.

## Testing

How can this contribution be tested? Use the following structure:

- Test step 1. Post an event with privacy option.
- Test step 2. Get this post.
- Test step 3. Post an event without privacy option.
- Test step 4. Try to get this post. The result must be null.
- Test step 5. Post an event with privacy option (with the value not being boolean).
- Test step 6. Try to get this post. The result must be null.
- Test step 7. List the events by privacy option. Send localhost:8080/event?privacy=false with Postman.
- Test step 8. The events without privacy must be listed.
- Test step 9. List the events by privacy option. Send localhost:8080/event?privacy=true with Postman.
- Test step 10. The events with privacy must be listed.
