### PR TITLE
Add methods and implement configurations for deleteEvent

### DIFF
--- a/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Controller/EventController.java
+++ b/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Controller/EventController.java
@@ -13,9 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.bounswe.bounswe2017group3;
+package com.bounswe.bounswe2017group3.Controller;
 
 import com.bounswe.bounswe2017group3.Exception.CustomException;
+import com.bounswe.bounswe2017group3.ErrorResponse;
+import com.bounswe.bounswe2017group3.Model.Event;
+import com.bounswe.bounswe2017group3.Model.User;
+import com.bounswe.bounswe2017group3.Repository.EventRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
@@ -35,11 +39,18 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.Calendar;
+
 @Controller
 @RequestMapping("/event")
 public class EventController {
 
-    private EventRepository repository;
+    private static final Date NULL = null;
+	private EventRepository repository;
 
     @Autowired
     public EventController(EventRepository repository) {
@@ -78,6 +89,18 @@ public class EventController {
         return event;
 
     }
+    
+    @RequestMapping(method=RequestMethod.DELETE, params="id", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public @ResponseBody Event deleteEvent(@RequestParam("id") long id,
+                                     @RequestParam MultiValueMap<String, String> params) {
+    	
+      Event update = repository.findById(id);
+
+      Calendar cal = Calendar.getInstance();
+      Date date = cal.getTime();
+      update.setDeletedAt(date);
+      return repository.save(update);
+   }
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse> exceptionHandler(Exception ex) {

--- a/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Controller/EventController.java
+++ b/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Controller/EventController.java
@@ -91,7 +91,7 @@ public class EventController {
     }
     
     @RequestMapping(method=RequestMethod.DELETE, params="id", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
-    public @ResponseBody Event deleteEvent(@RequestParam("id") long id,
+    public @ResponseBody void deleteEvent(@RequestParam("id") long id,
                                      @RequestParam MultiValueMap<String, String> params) {
     	
       Event update = repository.findById(id);
@@ -99,7 +99,7 @@ public class EventController {
       Calendar cal = Calendar.getInstance();
       Date date = cal.getTime();
       update.setDeletedAt(date);
-      return repository.save(update);
+      repository.save(update);
    }
 
     @ExceptionHandler(CustomException.class)

--- a/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Controller/EventController.java
+++ b/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Controller/EventController.java
@@ -29,6 +29,8 @@ import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
 import javax.validation.Valid;
 import java.util.List;
 import org.springframework.http.HttpStatus;
@@ -90,9 +92,9 @@ public class EventController {
 
     }
     
+    //Delete method is implemented to delete an event.
     @RequestMapping(method=RequestMethod.DELETE, params="id", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
-    public @ResponseBody void deleteEvent(@RequestParam("id") long id,
-                                     @RequestParam MultiValueMap<String, String> params) {
+    public @ResponseBody ResponseEntity<Void> deleteEvent(@RequestParam("id") long id) {
     	
       Event update = repository.findById(id);
 
@@ -100,6 +102,7 @@ public class EventController {
       Date date = cal.getTime();
       update.setDeletedAt(date);
       repository.save(update);
+      return new ResponseEntity<Void>(HttpStatus.NO_CONTENT);
    }
 
     @ExceptionHandler(CustomException.class)

--- a/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Model/Event.java
+++ b/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Model/Event.java
@@ -1,10 +1,13 @@
-package com.bounswe.bounswe2017group3;
+package com.bounswe.bounswe2017group3.Model;
 
 import org.hibernate.validator.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
 
 import javax.persistence.*;
 import java.io.Serializable;
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 @Table(name = "events")
@@ -42,6 +45,11 @@ public class Event implements Serializable {
      * Location of the event.
      */
     private String location;
+    
+    /**
+     * Deletion Date of the event.
+     */
+    private Date deletedAt;
 
     /**
      * Returns the id of the event.
@@ -116,10 +124,23 @@ public class Event implements Serializable {
     public Date getDate(){ return date;}
 
     /**
-     * Sets the date od the event.
+     * Sets the date of the event.
      * @param date date of the event.
      */
     public void setDate(Date date) {this.date = date;}
+    
+    /**
+     * Returns the deletion date of the event.
+     *
+     * @return date of the event.
+     */
+    public Date getDeletedAt(){ return deletedAt;}
+
+    /**
+     * Sets the deletion date of the event.
+     * @param date date of the event.
+     */
+    public void setDeletedAt(Date deletedAt) {this.deletedAt = deletedAt;}
     
     /*
     Privacy Option
@@ -133,6 +154,7 @@ public class Event implements Serializable {
     //Sets the privacy option of the event.
     public void setPrivacy(Boolean privacy) {this.privacy = privacy;}
     
+
     /**
      * Returns the string representation of the event object.
      *

--- a/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Repository/EventRepository.java
+++ b/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Repository/EventRepository.java
@@ -1,10 +1,15 @@
-package com.bounswe.bounswe2017group3;
+package com.bounswe.bounswe2017group3.Repository;
 
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import com.bounswe.bounswe2017group3.Model.Event;
 
 @Repository
 public interface EventRepository extends JpaRepository<Event, Long> {
@@ -13,6 +18,9 @@ public interface EventRepository extends JpaRepository<Event, Long> {
 
     //List events with respect to privacy option  
     public List<Event> findByPrivacy(Boolean privacy);
+    public Event findById(long id);
+    
+
     
     @Query("SELECT COUNT(e) FROM Event e where e.name = :name")
     public int numberOfEventsWithName(@Param("name") String name);

--- a/events-application-rest-api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/events-application-rest-api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -75,3 +75,13 @@ changeSet:
           name: privacy
           type: boolean
       tableName: events
+changeSet:
+  id: 5
+  author: MuratToygar
+  changes:
+  - addColumn:
+      columns:
+      - column:
+          name: deletedAt
+          type: timestamp
+      tableName: events


### PR DESCRIPTION
## About

* **Related Issues:** #72 

A DELETE request is implemented to delete an event.

### Changes

- `deletedAt` attribute is added to `Event` class. `setDeletedAt` and `getDeletedAt` is implemented.
- `findById` is added for `EventRepository`
- a `DELETE` endpoint is added to update `deletedAt` field of an event.

## Visuals

- An example query to test delete an event
![image](https://cloud.githubusercontent.com/assets/22214691/25575700/41a42404-2e62-11e7-9866-3b89604a5dd2.png)
- The response
![image](https://cloud.githubusercontent.com/assets/22214691/25575713/55ef6c0c-2e62-11e7-9028-bf3d0be75106.png)
