### PR TITLE
Implement the endpoint for retrieving all events

### DIFF
--- a/events-application-rest-api/README.md
+++ b/events-application-rest-api/README.md
@@ -127,8 +127,8 @@ You may update a user using this action. It takes a JSON object containing the n
 You may delete an user using this action. It takes a query param to know which user to delete. The deletedAt attribute of the deleted user will be set to the current date.
 
 + Parameters
-+ username (String) - The username of the user that'll be deleted, which is received as a query parameter. 
-+ id (long) - The id of the user that'll be deleted. 
+  + username (String) - The username of the user that'll be deleted, which is received as a query parameter. 
+  + id (long) - The id of the user that'll be deleted. 
 
 + Request (application/json)
 ```json

--- a/events-application-rest-api/README.md
+++ b/events-application-rest-api/README.md
@@ -28,7 +28,7 @@ This resource does not have any attributes. Instead it offers some information a
     + username (optional, string) - The username of the user to retrieve
     + email (optional, string) - The email of the user to retrieve
 
-A User object has the following attributes:
+A `User` object has the following attributes:
 
 + id (set automatically)
 + username
@@ -84,7 +84,7 @@ You may create your own user using this action. It takes a JSON object containin
 }
 ```
 
-+ Response 200 (application/json)
++ Response 201 (application/json)
 
 ```json
 {
@@ -119,34 +119,6 @@ You may update a user using this action. It takes a JSON object containing the n
   "username": "smddzcy",
   "email": "smddzcy@gmail.com",
   "fullname": "Ahmet Büyük"
-}
-```
-
-### Delete an Event [DELETE]
-
-You may delete an event using this action. It takes a query param to know which user to delete. The deletedAt attribute of the deleted user will be set to the current date.
-
-+ Parameters
-    + id (long) - The id of the event that'll be deleted, which is received as a query parameter. 
-
-+ Request (application/json)
-```json
-{
-  "id": "30"
-}
-```
-+ Response 204 (No Content)
-
-+ Deleted Event with deletedAt field set after deletion (application/json)
-```
-{
- "id": 30,
- "name": "deneme231",
- "description": null,
- "date": null,
- "location": null,
- "deletedAt": 1493645656885,
- "privacy": false
 }
 ```
 
@@ -196,6 +168,109 @@ You may delete an user using this action. It takes a query param to know which u
 }
 ```
 
+## Events Collection [/event{?name&privacy}]
+
++ Parameters
+    + name (optional, string) - The name of the event to retrieve
+    + privacy (optional, boolean) - The privacy of the event to retrieve
+
+A `Event` object has the following attributes:
+
++ id (set automatically)
++ name
++ description (optional)
++ date (optional)
++ location (optional)
++ privacy
+
+### List All Events [GET]
+
++ Response 200 (application/json)
+
+```json
+[
+  {
+    "id": 1,
+    "name": "Tennis Event",
+    "description": "Private tennis match",
+    "date": "21.05.2017 17:00",
+    "location": "Bebek / Istanbul",
+    "privacy": true
+  },
+   {
+    "id": 2,
+    "name": "FB / GS Match",
+    "description": null,
+    "date": "23.05.2017 17:00",
+    "location": "Şükrü Saraçoğlu",
+    "privacy": false
+  }
+]
+```
+
+### Create a New Event [POST]
+
+You may create your own event using this action. It takes a JSON object containing the event fields with its values.
+
++ Parameters
+    + name (string) - Name of the event
+    + description (string, optional) - Description of the event
+    + date (datetime, optional) - Date and time of the event
+    + location (string, optional) - Location of the event
+    + privacy (boolean) - Is the event private or public (True if private, false if public)
+
++ Request (application/json)
+
+```json
+{
+  "name": "Tennis Event",
+  "description": "Private tennis match",
+  "date": "21.05.2017 17:00",
+  "location": "Bebek / Istanbul",
+  "privacy": true
+}
+```
+
++ Response 201 (application/json)
+
+```json
+{
+  "id": 1,
+  "name": "Tennis Event",
+  "description": "Private tennis match",
+  "date": "21.05.2017 17:00",
+  "location": "Bebek / Istanbul",
+  "privacy": true
+}
+```
+
+### Delete an Event [DELETE]
+
+You may delete an event using this action. It takes a query param to know which event to delete. The deletedAt attribute of the deleted event will be set to the current date.
+
++ Parameters
+    + id (long) - The id of the event that'll be deleted, which is received as a query parameter. 
+
++ Request (application/json)
+```json
+{
+  "id": "30"
+}
+```
++ Response 204 (No Content)
+
++ Deleted Event with deletedAt field set after deletion (application/json)
+```
+{
+ "id": 30,
+ "name": "deneme231",
+ "description": null,
+ "date": null,
+ "location": null,
+ "deletedAt": 1493645656885,
+ "privacy": false
+}
+```
 
 # Setting Up the Development Environment
 

--- a/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Controller/EventController.java
+++ b/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Controller/EventController.java
@@ -44,6 +44,14 @@ public class EventController {
         this.repository = repository;
     }
 
+    @RequestMapping(method = RequestMethod.GET,
+        produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+    public
+    @ResponseBody
+    List<Event> event() {
+        return repository.findAll();
+    }
+
     @RequestMapping(method = RequestMethod.GET, value = "",
         params = "name",
         produces = MediaType.APPLICATION_JSON_UTF8_VALUE)

--- a/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Controller/EventController.java
+++ b/events-application-rest-api/src/main/java/com/bounswe/bounswe2017group3/Controller/EventController.java
@@ -91,12 +91,11 @@ public class EventController {
     }
 
     //Delete method is implemented to delete an event.
-    @RequestMapping(method = RequestMethod.DELETE, params = "id", produces =
+    @RequestMapping(method = RequestMethod.DELETE, value = "/{id}", produces =
         MediaType.APPLICATION_JSON_UTF8_VALUE)
     public
     @ResponseBody
-    ResponseEntity<Void> deleteEvent(@RequestParam("id") long id) {
-
+    ResponseEntity<Void> deleteEvent(@PathVariable("id") long id) {
         Event update = repository.findById(id);
 
         Calendar cal = Calendar.getInstance();


### PR DESCRIPTION
## About

* **Related Issues:** https://github.com/bounswe/bounswe2017group3/issues/72

I've implemented one of the most necessary endpoints, which is _retrieving all events_, since no one has implemented this.

### Changes

- Implement the endpoint for retrieving all events, which is `GET /event`.
- Add the new documentations and the **missing ones**.
  - The documentations for creating and updating events were missing. Please read our contribution guide and don't forget to include documentations with your code. Also, please don't approve pull requests that don't contain documentations.
- Fix the path variable and query param confusion in delete event endpoint.

## Visuals
`GET /event`
![screen shot 2017-05-16 at 00 53 41](https://cloud.githubusercontent.com/assets/13895224/26081140/2c7273da-39d2-11e7-9186-75faa398682f.png)

`DELETE /event/:id`
![screen shot 2017-05-16 at 00 53 50](https://cloud.githubusercontent.com/assets/13895224/26081148/35a53424-39d2-11e7-855a-581181c67bc1.png)

## Testing

- Send a GET request to `https://bounswe2017group3.herokuapp.com/event`.
- Response status should be `200 OK`.
- It should respond with the `application/json` content type and contain all the events in a JSON array.
